### PR TITLE
Support HalfBinaryExpression

### DIFF
--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -181,10 +181,19 @@ public class DrlxParserTest {
         assertEquals(expr, toDrlx(expression));
     }
 
-    @Test(expected = ParseProblemException.class)
+    @Test
+    /* This shouldn't be supported, an HalfBinaryExpr should be valid only after a && or a || */
     public void testUnsupportedImplicitParameter() {
         String expr = "== \"Mark\"";
-        DrlxParser.parseExpression( expr ).getExpr();
+        Expression expression = DrlxParser.parseExpression( expr ).getExpr();
+        assertTrue(expression instanceof HalfBinaryExpr);
+        assertEquals(expr, toDrlx(expression));
+    }
+
+    @Test(expected = ParseProblemException.class)
+    public void testUnsupportedImplicitParameterWithJavaParser() {
+        String expr = "== \"Mark\"";
+        JavaParser.parseExpression( expr );
     }
 
     @Test

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.HalfBinaryExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import org.junit.Test;
 
@@ -181,7 +182,7 @@ public class DrlxParserTest {
 
     @Test
     public void testOrWithImplicitParameter() {
-        String expr = "name == \"Mark\" || name == \"Mario\"";
+        String expr = "name == \"Mark\" || == \"Mario\"";
         Expression expression = DrlxParser.parseExpression( expr ).getExpr();
         System.out.println(expression);
 
@@ -193,8 +194,7 @@ public class DrlxParserTest {
         assertEquals("\"Mark\"", left.getRight().toString());
         assertEquals(Operator.EQUALS, left.getOperator());
 
-        BinaryExpr right = (BinaryExpr) comboExpr.getRight();
-        assertEquals("name", right.getLeft().toString());
+        HalfBinaryExpr right = (HalfBinaryExpr) comboExpr.getRight();
         assertEquals("\"Mario\"", right.getRight().toString());
         assertEquals(Operator.EQUALS, right.getOperator());
     }

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -180,6 +180,12 @@ public class DrlxParserTest {
         assertEquals(expr, toDrlx(expression));
     }
 
+    @Test(expected = ParseProblemException.class)
+    public void testUnsupportedImplicitParameter() {
+        String expr = "== \"Mark\"";
+        DrlxParser.parseExpression( expr ).getExpr();
+    }
+
     @Test
     public void testOrWithImplicitParameter() {
         String expr = "name == \"Mark\" || == \"Mario\" || == \"Luca\"";
@@ -203,28 +209,26 @@ public class DrlxParserTest {
         assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
     }
 
-    @Test(expected = ParseProblemException.class)
-    public void testUnsupportedImplicitParameter() {
-        String expr = "== \"Mark\"";
-        DrlxParser.parseExpression( expr ).getExpr();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testOrWithImplicitParameter2() {
-        String expr = "name == \"Mark\" && == \"Mario\"";
+    @Test
+    public void testAndWithImplicitParameter() {
+        String expr = "name == \"Mark\" && == \"Mario\" && == \"Luca\"";
         Expression expression = DrlxParser.parseExpression( expr ).getExpr();
         System.out.println(expression);
 
         BinaryExpr comboExpr = ( (BinaryExpr) expression );
-        assertEquals(Operator.OR, comboExpr.getOperator());
+        assertEquals(Operator.AND, comboExpr.getOperator());
 
-        BinaryExpr left = (BinaryExpr) comboExpr.getLeft();
-        assertEquals("name", left.getLeft().toString());
-        assertEquals("\"Mark\"", left.getRight().toString());
-        assertEquals(Operator.EQUALS, left.getOperator());
+        BinaryExpr first = ((BinaryExpr)((BinaryExpr) comboExpr.getLeft()).getLeft());
+        assertEquals("name", first.getLeft().toString());
+        assertEquals("\"Mark\"", first.getRight().toString());
+        assertEquals(Operator.EQUALS, first.getOperator());
 
-        HalfBinaryExpr right = (HalfBinaryExpr) comboExpr.getRight();
-        assertEquals("\"Mario\"", right.getRight().toString());
-        assertEquals(Operator.EQUALS, right.getOperator());
+        HalfBinaryExpr second = (HalfBinaryExpr) ((BinaryExpr) comboExpr.getLeft()).getRight();
+        assertEquals("\"Mario\"", second.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, second.getOperator());
+
+        HalfBinaryExpr third = (HalfBinaryExpr) comboExpr.getRight();
+        assertEquals("\"Luca\"", third.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
     }
 }

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -231,4 +231,28 @@ public class DrlxParserTest {
         assertEquals("\"Luca\"", third.getRight().toString());
         assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
     }
+
+    @Test
+    public void testAndWithImplicitParameter2() {
+        String expr = "name == \"Mark\" && == \"Mario\" || == \"Luca\"";
+        Expression expression = DrlxParser.parseExpression( expr ).getExpr();
+        System.out.println(expression);
+
+        BinaryExpr comboExpr = ( (BinaryExpr) expression );
+        assertEquals(Operator.OR, comboExpr.getOperator());
+        assertEquals(Operator.AND, ((BinaryExpr)(comboExpr.getLeft())).getOperator());
+
+        BinaryExpr first = ((BinaryExpr)((BinaryExpr) comboExpr.getLeft()).getLeft());
+        assertEquals("name", first.getLeft().toString());
+        assertEquals("\"Mark\"", first.getRight().toString());
+        assertEquals(Operator.EQUALS, first.getOperator());
+
+        HalfBinaryExpr second = (HalfBinaryExpr) ((BinaryExpr) comboExpr.getLeft()).getRight();
+        assertEquals("\"Mario\"", second.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, second.getOperator());
+
+        HalfBinaryExpr third = (HalfBinaryExpr) comboExpr.getRight();
+        assertEquals("\"Luca\"", third.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
+    }
 }

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -203,6 +203,12 @@ public class DrlxParserTest {
         assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
     }
 
+    @Test(expected = ParseProblemException.class)
+    public void testUnsupportedImplicitParameter() {
+        String expr = "== \"Mark\"";
+        DrlxParser.parseExpression( expr ).getExpr();
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testOrWithImplicitParameter2() {
         String expr = "name == \"Mark\" && == \"Mario\"";

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -178,4 +178,24 @@ public class DrlxParserTest {
         assertTrue(expression instanceof PointFreeExpr);
         assertEquals(expr, toDrlx(expression));
     }
+
+    @Test
+    public void testOrWithImplicitParameter() {
+        String expr = "name == \"Mark\" || name == \"Mario\"";
+        Expression expression = DrlxParser.parseExpression( expr ).getExpr();
+        System.out.println(expression);
+
+        BinaryExpr comboExpr = ( (BinaryExpr) expression );
+        assertEquals(Operator.OR, comboExpr.getOperator());
+
+        BinaryExpr left = (BinaryExpr) comboExpr.getLeft();
+        assertEquals("name", left.getLeft().toString());
+        assertEquals("\"Mark\"", left.getRight().toString());
+        assertEquals(Operator.EQUALS, left.getOperator());
+
+        BinaryExpr right = (BinaryExpr) comboExpr.getRight();
+        assertEquals("name", right.getLeft().toString());
+        assertEquals("\"Mario\"", right.getRight().toString());
+        assertEquals(Operator.EQUALS, right.getOperator());
+    }
 }

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -182,7 +182,30 @@ public class DrlxParserTest {
 
     @Test
     public void testOrWithImplicitParameter() {
-        String expr = "name == \"Mark\" || == \"Mario\"";
+        String expr = "name == \"Mark\" || == \"Mario\" || == \"Luca\"";
+        Expression expression = DrlxParser.parseExpression( expr ).getExpr();
+        System.out.println(expression);
+
+        BinaryExpr comboExpr = ( (BinaryExpr) expression );
+        assertEquals(Operator.OR, comboExpr.getOperator());
+
+        BinaryExpr first = ((BinaryExpr)((BinaryExpr) comboExpr.getLeft()).getLeft());
+        assertEquals("name", first.getLeft().toString());
+        assertEquals("\"Mark\"", first.getRight().toString());
+        assertEquals(Operator.EQUALS, first.getOperator());
+
+        HalfBinaryExpr second = (HalfBinaryExpr) ((BinaryExpr) comboExpr.getLeft()).getRight();
+        assertEquals("\"Mario\"", second.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, second.getOperator());
+
+        HalfBinaryExpr third = (HalfBinaryExpr) comboExpr.getRight();
+        assertEquals("\"Luca\"", third.getRight().toString());
+        assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testOrWithImplicitParameter2() {
+        String expr = "name == \"Mark\" && == \"Mario\"";
         Expression expression = DrlxParser.parseExpression( expr ).getExpr();
         System.out.println(expression);
 

--- a/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
+++ b/drlx-parser/src/test/java/org/drools/drlx/DrlxParserTest.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.HalfBinaryExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
 import org.junit.Test;
 
 import static com.github.javaparser.printer.PrintUtil.toDrlx;
@@ -254,5 +255,31 @@ public class DrlxParserTest {
         HalfBinaryExpr third = (HalfBinaryExpr) comboExpr.getRight();
         assertEquals("\"Luca\"", third.getRight().toString());
         assertEquals(HalfBinaryExpr.Operator.EQUALS, third.getOperator());
+    }
+
+    @Test
+    public void regressionTestImplicitOperator() {
+        String expr =
+        "{ " +
+        "   for (i = 0; i < 10 && i < 2; i++) {\n" +
+        "            break;\n" +
+        "   }\n" +
+        "}";
+        BlockStmt expression = JavaParser.parseBlock(expr );
+        System.out.println(expression);
+    }
+
+    @Test
+    public void regressionTestImplicitOperator2() {
+        String expr = "i < 10 && i < 2";
+        Expression expression = JavaParser.parseExpression(expr );
+        System.out.println(expression);
+    }
+
+    @Test
+    public void regressionTestImplicitOperator3() {
+        String expr = "i == 10 && i == 2";
+        Expression expression = JavaParser.parseExpression(expr );
+        System.out.println(expression);
     }
 }

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
@@ -89,7 +89,7 @@ public final class HalfBinaryExpr extends Expression {
 
     @Override
     public <A> void accept(VoidVisitor<A> v, A arg) {
-        throw new UnsupportedOperationException();
+        v.visit(this, arg);
     }
 
     @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
@@ -47,7 +47,7 @@ public final class HalfBinaryExpr extends Expression {
 
     public enum Operator implements Printable {
 
-        OR("||"), AND("&&"), BINARY_OR("|"), BINARY_AND("&"), XOR("^"), EQUALS("=="), NOT_EQUALS("!="), LESS("<"), GREATER(">"), LESS_EQUALS("<="), GREATER_EQUALS(">="), LEFT_SHIFT("<<"), SIGNED_RIGHT_SHIFT(">>"), UNSIGNED_RIGHT_SHIFT(">>>"), PLUS("+"), MINUS("-"), MULTIPLY("*"), DIVIDE("/"), REMAINDER("%");
+        EQUALS("=="), NOT_EQUALS("!="), LESS("<"), GREATER(">"), LESS_EQUALS("<="), GREATER_EQUALS(">=");
 
         private final String codeRepresentation;
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/expr/HalfBinaryExpr.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2007-2010 Júlio Vilmar Gesser.
+ * Copyright (C) 2011, 2013-2016 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+package com.github.javaparser.ast.expr;
+
+import javax.annotation.Generated;
+
+import com.github.javaparser.TokenRange;
+import com.github.javaparser.ast.AllFieldsConstructor;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.ast.visitor.CloneVisitor;
+import com.github.javaparser.ast.visitor.GenericVisitor;
+import com.github.javaparser.ast.visitor.VoidVisitor;
+import com.github.javaparser.metamodel.BinaryExprMetaModel;
+import com.github.javaparser.metamodel.JavaParserMetaModel;
+import com.github.javaparser.printer.Printable;
+
+import static com.github.javaparser.utils.Utils.assertNotNull;
+
+/**
+ * An expression with an expression on the left, an expression on the right, and an operator in the middle.
+ * It supports the operators that are found the the BinaryExpr.Operator enum.
+ * <br/><code>a && b</code>
+ * <br/><code>155 * 33</code>
+ *
+ * @author Julio Vilmar Gesser
+ */
+public final class HalfBinaryExpr extends Expression {
+
+    public enum Operator implements Printable {
+
+        OR("||"), AND("&&"), BINARY_OR("|"), BINARY_AND("&"), XOR("^"), EQUALS("=="), NOT_EQUALS("!="), LESS("<"), GREATER(">"), LESS_EQUALS("<="), GREATER_EQUALS(">="), LEFT_SHIFT("<<"), SIGNED_RIGHT_SHIFT(">>"), UNSIGNED_RIGHT_SHIFT(">>>"), PLUS("+"), MINUS("-"), MULTIPLY("*"), DIVIDE("/"), REMAINDER("%");
+
+        private final String codeRepresentation;
+
+        Operator(String codeRepresentation) {
+            this.codeRepresentation = codeRepresentation;
+        }
+
+        public String asString() {
+            return codeRepresentation;
+        }
+    }
+
+    private Expression right;
+
+    private Operator operator;
+
+    public HalfBinaryExpr() {
+        this(null, new BooleanLiteralExpr(), Operator.EQUALS);
+    }
+
+    @AllFieldsConstructor
+    public HalfBinaryExpr(Expression right, Operator operator) {
+        this(null, right, operator);
+    }
+
+    /**This constructor is used by the parser and is considered private.*/
+    @Generated("com.github.javaparser.generator.core.node.MainConstructorGenerator")
+    public HalfBinaryExpr(TokenRange tokenRange, Expression right, Operator operator) {
+        super(tokenRange);
+        setRight(right);
+        setOperator(operator);
+        customInitialization();
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public Operator getOperator() {
+        return operator;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public Expression getRight() {
+        return right;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public HalfBinaryExpr setOperator(final Operator operator) {
+        assertNotNull(operator);
+        if (operator == this.operator) {
+            return (HalfBinaryExpr) this;
+        }
+        notifyPropertyChange(ObservableProperty.OPERATOR, this.operator, operator);
+        this.operator = operator;
+        return this;
+    }
+
+    @Generated("com.github.javaparser.generator.core.node.PropertyGenerator")
+    public HalfBinaryExpr setRight(final Expression right) {
+        assertNotNull(right);
+        if (right == this.right) {
+            return (HalfBinaryExpr) this;
+        }
+        notifyPropertyChange(ObservableProperty.RIGHT, this.right, right);
+        if (this.right != null)
+            this.right.setParentNode(null);
+        this.right = right;
+        setAsParentNodeOf(right);
+        return this;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.RemoveMethodGenerator")
+    public boolean remove(Node node) {
+        if (node == null)
+            return false;
+        return super.remove(node);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.CloneGenerator")
+    public HalfBinaryExpr clone() {
+        return (HalfBinaryExpr) accept(new CloneVisitor(), null);
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.GetMetaModelGenerator")
+    public BinaryExprMetaModel getMetaModel() {
+        return JavaParserMetaModel.binaryExprMetaModel;
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.node.ReplaceMethodGenerator")
+    public boolean replace(Node node, Node replacementNode) {
+        if (node == null)
+            return false;
+        if (node == right) {
+            setRight((Expression) replacementNode);
+            return true;
+        }
+        return super.replace(node, replacementNode);
+    }
+}

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitor.java
@@ -307,6 +307,8 @@ public interface VoidVisitor<A> {
     @Generated("com.github.javaparser.generator.core.visitor.VoidVisitorGenerator")
     void visit(UnparsableStmt n, A arg);
 
+    void visit(HalfBinaryExpr n, A arg);
+
     VoidRuleVisitor DUMMY_RULE_VISITOR = new VoidRuleVisitor() {
     };
 

--- a/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/ast/visitor/VoidVisitorAdapter.java
@@ -110,6 +110,13 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
 
     @Override
     @Generated("com.github.javaparser.generator.core.visitor.VoidVisitorAdapterGenerator")
+    public void visit(final HalfBinaryExpr n, final A arg) {
+        n.getRight().accept(this, arg);
+        n.getComment().ifPresent(l -> l.accept(this, arg));
+    }
+
+    @Override
+    @Generated("com.github.javaparser.generator.core.visitor.VoidVisitorAdapterGenerator")
     public void visit(final BlockComment n, final A arg) {
         n.getComment().ifPresent(l -> l.accept(this, arg));
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -676,7 +676,6 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     @Override
     public void visit(HalfBinaryExpr n, Void arg) {
         printJavaComment(n.getComment(), arg);
-        printer.print(" ");
         printer.print(n.getOperator().asString());
         printer.print(" ");
         n.getRight().accept(this, arg);

--- a/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/PrettyPrintVisitor.java
@@ -69,6 +69,7 @@ import com.github.javaparser.ast.expr.DoubleLiteralExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.HalfBinaryExpr;
 import com.github.javaparser.ast.expr.InstanceOfExpr;
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
@@ -666,6 +667,15 @@ public class PrettyPrintVisitor implements VoidVisitor<Void> {
     public void visit(final BinaryExpr n, final Void arg) {
         printJavaComment(n.getComment(), arg);
         n.getLeft().accept(this, arg);
+        printer.print(" ");
+        printer.print(n.getOperator().asString());
+        printer.print(" ");
+        n.getRight().accept(this, arg);
+    }
+
+    @Override
+    public void visit(HalfBinaryExpr n, Void arg) {
+        printJavaComment(n.getComment(), arg);
         printer.print(" ");
         printer.print(n.getOperator().asString());
         printer.print(" ");

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1633,7 +1633,27 @@ Expression ConditionalOrExpression():
 	Expression right;
 }
 {
-  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
+  ret = ConditionalOrHalfBinaryExpression() ( "||" right = ConditionalOrHalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
+  { return ret; }
+}
+
+Expression ConditionalOrHalfBinaryExpression():
+{
+	Expression ret;
+	Expression right;
+}
+{
+  ret = ConditionalAndHalfBinaryExpression() ( "||" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
+  { return ret; }
+}
+
+Expression ConditionalAndHalfBinaryExpression():
+{
+	Expression ret;
+	Expression right;
+}
+{
+  ret = ConditionalAndExpression() ( "&&" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
 
@@ -1646,6 +1666,27 @@ Expression ConditionalAndExpression():
   ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
+
+Expression HalfBinaryExpression():
+{
+	Expression ret;
+	HalfBinaryExpr.Operator op;
+	JavaToken begin = INVALID;
+}
+{
+  (
+	  ( "==" { op = HalfBinaryExpr.Operator.EQUALS; begin=token();} |
+	    "!=" { op = HalfBinaryExpr.Operator.NOT_EQUALS; begin=token();}
+	  ) ret = HalfBinaryExpression()
+	  {
+        ret = new HalfBinaryExpr(range(begin, token()), ret, op);
+	  }
+	|
+	  ret = UnaryExpression()
+  )
+  { return ret; }
+}
+
 
 Expression InclusiveOrExpression():
 {

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1676,7 +1676,11 @@ Expression HalfBinaryExpression():
 {
   (
 	  ( "==" { op = HalfBinaryExpr.Operator.EQUALS; begin=token();} |
-	    "!=" { op = HalfBinaryExpr.Operator.NOT_EQUALS; begin=token();}
+	    "!=" { op = HalfBinaryExpr.Operator.NOT_EQUALS; begin=token();} |
+	    "<" { op = HalfBinaryExpr.Operator.LESS; begin=token();} |
+	    ">" { op = HalfBinaryExpr.Operator.GREATER; begin=token();} |
+	    "<=" { op = HalfBinaryExpr.Operator.LESS_EQUALS; begin=token();} |
+	    ">=" { op = HalfBinaryExpr.Operator.GREATER_EQUALS; begin=token();}
 	  ) ret = HalfBinaryExpression()
 	  {
         ret = new HalfBinaryExpr(range(begin, token()), ret, op);

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1633,17 +1633,7 @@ Expression ConditionalOrExpression():
 	Expression right;
 }
 {
-  ret = ConditionalOrHalfBinaryExpression() ( "||" right = ConditionalOrHalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
-  { return ret; }
-}
-
-Expression ConditionalOrHalfBinaryExpression():
-{
-	Expression ret;
-	Expression right;
-}
-{
-  ret = ConditionalAndExpression() ( "||" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
+  ret = ConditionalAndExpression() ( "||" right = ConditionalAndExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
   { return ret; }
 }
 
@@ -1653,44 +1643,9 @@ Expression ConditionalAndExpression():
 	Expression right;
 }
 {
-  ret = ConditionalAndHalfBinaryExpression() ( "&&" right = ConditionalAndHalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
-
-Expression ConditionalAndHalfBinaryExpression():
-{
-	Expression ret;
-	Expression right;
-}
-{
-  ret = InclusiveOrExpression() ( "&&" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
-  { return ret; }
-}
-
-Expression HalfBinaryExpression():
-{
-	Expression ret;
-	HalfBinaryExpr.Operator op;
-	JavaToken begin = INVALID;
-}
-{
-  (
-	  ( "==" { op = HalfBinaryExpr.Operator.EQUALS; begin=token();} |
-	    "!=" { op = HalfBinaryExpr.Operator.NOT_EQUALS; begin=token();} |
-	    "<" { op = HalfBinaryExpr.Operator.LESS; begin=token();} |
-	    ">" { op = HalfBinaryExpr.Operator.GREATER; begin=token();} |
-	    "<=" { op = HalfBinaryExpr.Operator.LESS_EQUALS; begin=token();} |
-	    ">=" { op = HalfBinaryExpr.Operator.GREATER_EQUALS; begin=token();}
-	  ) ret = HalfBinaryExpression()
-	  {
-        ret = new HalfBinaryExpr(range(begin, token()), ret, op);
-	  }
-	|
-	  ret = UnaryExpression()
-  )
-  { return ret; }
-}
-
 
 Expression InclusiveOrExpression():
 {
@@ -1839,7 +1794,7 @@ Expression UnaryExpression():
         ret = new UnaryExpr(range(begin, token()), ret, op);
 	  }
 	|
-	  ret = UnaryExpressionNotPlusMinus()
+	  ret = HalfBinaryExpression()
   )
   { return ret; }
 }
@@ -1863,6 +1818,34 @@ Expression PreDecrementExpression():
   "--" {begin=token();} ret = UnaryExpression() { ret = new UnaryExpr(range(begin, token()), ret, UnaryExpr.Operator.PREFIX_DECREMENT); }
   { return ret; }
 }
+
+// drlx start
+Expression HalfBinaryExpression():
+{
+	Expression ret;
+	HalfBinaryExpr.Operator op;
+	JavaToken begin = INVALID;
+	boolean isDrl = false;
+}
+{
+  (
+	  ( "==" { op = HalfBinaryExpr.Operator.EQUALS; begin=token();} |
+	    "!=" { op = HalfBinaryExpr.Operator.NOT_EQUALS; begin=token();} |
+	    "<" { op = HalfBinaryExpr.Operator.LESS; begin=token();} |
+	    ">" { op = HalfBinaryExpr.Operator.GREATER; begin=token();} |
+	    "<=" { op = HalfBinaryExpr.Operator.LESS_EQUALS; begin=token();} |
+	    ">=" { op = HalfBinaryExpr.Operator.GREATER_EQUALS; begin=token();}
+	  ) ret = HalfBinaryExpression()
+	  {
+	    isDrl = true;
+        ret = new HalfBinaryExpr(range(begin, token()), ret, op);
+	  }
+	|
+	  ret = UnaryExpressionNotPlusMinus()
+  )
+  { return isDrl ? asDrlNode(ret) : ret; }
+}
+// drlx end
 
 Expression UnaryExpressionNotPlusMinus():
 {

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1643,17 +1643,7 @@ Expression ConditionalOrHalfBinaryExpression():
 	Expression right;
 }
 {
-  ret = ConditionalAndHalfBinaryExpression() ( "||" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
-  { return ret; }
-}
-
-Expression ConditionalAndHalfBinaryExpression():
-{
-	Expression ret;
-	Expression right;
-}
-{
-  ret = ConditionalAndExpression() ( "&&" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = ConditionalAndExpression() ( "||" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.OR); } )*
   { return ret; }
 }
 
@@ -1663,7 +1653,17 @@ Expression ConditionalAndExpression():
 	Expression right;
 }
 {
-  ret = InclusiveOrExpression() ( "&&" right = InclusiveOrExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
+  ret = ConditionalAndHalfBinaryExpression() ( "&&" right = ConditionalAndHalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
+  { return ret; }
+}
+
+Expression ConditionalAndHalfBinaryExpression():
+{
+	Expression ret;
+	Expression right;
+}
+{
+  ret = InclusiveOrExpression() ( "&&" right = HalfBinaryExpression() { ret = new BinaryExpr(range(ret.getTokenRange().get().getBegin(), token()), ret, right, BinaryExpr.Operator.AND); } )*
   { return ret; }
 }
 


### PR DESCRIPTION
An HalfBinaryExpression is a BinaryExpression without the first part, used while concatenating binary expr such as

```
i > 2 && < 10 && == 5
```

`< 10` and `== 5` are HalfBinaryExpressions


