### PR TITLE
drop NOT_WITH_SPACE as it no longer conflicts with other rules

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/TokenTypes.java
@@ -235,10 +235,9 @@ public class TokenTypes {
             case MVEL_ENDS_WITH:
             case MVEL_LENGTH:
             case NOT:
-            case NOT_WITH_SPACE:
+            case 148:
             case 149:
             case 150:
-            case 151:
                 return JavaToken.Category.DRLX;
             // The following are tokens that are only used internally by the lexer
             case ENTER_JAVADOC_COMMENT:

--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -291,7 +291,6 @@ TOKEN :
 | < TRANSITIVE: "transitive" >
 | < RULE: "rule" >
 | < NOT: "not" >
-| < NOT_WITH_SPACE: " not" >
 | < MVEL_STARTS_WITH: "str[startsWith]" >
 | < MVEL_ENDS_WITH: "str[endsWith]" >
 | < MVEL_LENGTH: "str[length]" >
@@ -3083,7 +3082,7 @@ Expression PointFreeExpr():
         (
             left = PrimaryExpression() { begin=token(); }
             (
-                          <NOT_WITH_SPACE>
+                          <NOT>
                           { negated = true; }
             )*
             (
@@ -3121,7 +3120,7 @@ Expression PointFreeExprMvel():
         (
             left = PrimaryExpression() { begin=token(); }
             (
-                          <NOT_WITH_SPACE>
+                          <NOT>
                           { negated = true; }
             )*
             (

--- a/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
+++ b/javaparser-testing/src/test/java/com/github/javaparser/JavaParserTest.java
@@ -220,7 +220,7 @@ public class JavaParserTest {
         int switchEntries = tokenTypesCu.findAll(SwitchEntryStmt.class).size()-1;
         // The amount of "case XXX:" in TokenTypes.java should be equal to the amount of tokens JavaCC knows about:
         // DRLX we have other tokens now and not everyone has a category
-        assertEquals(156, tokenCount);
+        assertEquals(155, tokenCount);
     }
 
     @Test


### PR DESCRIPTION
using plain NOT token no longer causes conflicts with other syntax rules; all tests are green, so we can safely drop NOT_WITH_SPACE