### PR TITLE
Include in '-sources' classifier JAR also upstream JP sources as shaded

### DIFF
--- a/drlx-parser/pom.xml
+++ b/drlx-parser/pom.xml
@@ -52,6 +52,8 @@
                             <shadedPattern>org.drools.javaparser</shadedPattern>
                         </relocation>
                     </relocations>
+                    <createSourcesJar>true</createSourcesJar>
+                    <shadeSourcesContent>true</shadeSourcesContent> <!-- the -sources classifier JAR to also contain sources of upstream JP -->
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
/cc @etirelli @mariofusco @lucamolteni 

Before Vs After `-sources` classifier JAR:

![image](https://user-images.githubusercontent.com/1699252/40987165-342accd0-68e8-11e8-8a91-0f7e696b63f8.png)

After `-sources` classifier JAR:

![image](https://user-images.githubusercontent.com/1699252/40987268-6e77b77c-68e8-11e8-8143-e818417d9a36.png)

Example use for development time:

![image](https://user-images.githubusercontent.com/1699252/40987412-be456308-68e8-11e8-8855-df4e2ffa8ce9.png)

Result before:

![image](https://user-images.githubusercontent.com/1699252/40987456-dc8a9e6e-68e8-11e8-8ea1-905c2a92a2d3.png)

Result after:

![image](https://user-images.githubusercontent.com/1699252/40987513-fb9cf932-68e8-11e8-920f-157fdc525d36.png)

Debug time I expect would be analogous, and in addition line number now corresponding.