### PR TITLE
Ignore build output

### DIFF
--- a/drlx-parser/.gitignore
+++ b/drlx-parser/.gitignore
@@ -1,0 +1,1 @@
+/dependency-reduced-pom.xml

--- a/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/.gitignore
+++ b/javaparser-testing/src/test/resources/com/github/javaparser/bulk_test_results/.gitignore
@@ -1,0 +1,1 @@
+javaparser_test_results.txt


### PR DESCRIPTION
Quick fix to keep the working tree clean after Maven build.

Apparently, it's not easy to change `dependency-reduced-pom.xml` location to the target dir: https://stackoverflow.com/a/35155294/1691152