### PR TITLE
Align surefire version with kiegroup projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
         <maven-jacoco-plugin.version>0.7.9</maven-jacoco-plugin.version>
         <maven-coveralls-plugin.version>4.3.0</maven-coveralls-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
+        <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
         <bnd-maven-plugin.version>3.4.0</bnd-maven-plugin.version>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -227,7 +229,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>${maven-javadoc-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
@mariofusco could you please check and merge?
I'm trying to automate extraction of some useful information from build output (maven console logs).
This repo (unlike most other kiegroup repos) is using very old version of surefire (2.12), which means the test output is very different compared to other repos.
I'm bumping the version of surefire so it's aligned with surefire version used in other kiegroup repos.