### PR TITLE
Fix deployment to JBoss Nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,18 +132,6 @@
         <!-- Maven Plugins -->
     </properties>
 
-    <scm>
-        <connection>scm:git:git://github.com/javaparser/javaparser.git</connection>
-        <developerConnection>scm:git:git@github.com:javaparser/javaparser.git</developerConnection>
-        <url>https://github.com/javaparser/javaparser.git</url>
-        <tag>javaparser-parent-3.10.2</tag>
-    </scm>
-
-    <issueManagement>
-        <system>GitHub Issue Tracker</system>
-        <url>https://github.com/javaparser/javaparser/issues</url>
-    </issueManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,14 +144,6 @@
         <url>https://github.com/javaparser/javaparser/issues</url>
     </issueManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>bintray-javaparser-JavaParser</id>
-            <name>javaparser-JavaParser</name>
-            <url>https://api.bintray.com/maven/javaparser/JavaParser/javaparser/;publish=1</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Removes distributionManagement from parent pom.xml, because when deploying a new build, it tries to deploy to original Javaparser Maven repository. 

@mariofusco @lucamolteni could you please review?