### PR TITLE
Skip deploy where not needed

### DIFF
--- a/javaparser-core-serialization/pom.xml
+++ b/javaparser-core-serialization/pom.xml
@@ -26,6 +26,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<build.timestamp>${maven.build.timestamp}</build.timestamp>
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 
 	<build>

--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <java.version>1.8</java.version>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/javaparser-symbol-solver-logic/pom.xml
+++ b/javaparser-symbol-solver-logic/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <java.version>1.8</java.version>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/javaparser-symbol-solver-model/pom.xml
+++ b/javaparser-symbol-solver-model/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <java.version>1.8</java.version>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+      <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
   <dependencies>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -24,6 +24,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <profiles>
         <profile>
             <id>NonSlowTests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <java.version>1.8</java.version>
 
         <!-- Maven Plugins -->
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <build>


### PR DESCRIPTION
@mariofusco @lucamolteni this was lost as part of rebase I think. I checked 7.14.x branch and every module is skipping deployment except drlx-parser there. 